### PR TITLE
feat: impl use-loader-data-types rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ An ESLint plugin for [Remix](https://remix.run)
 ### `node-server-imports`:
 
 Ensures that all imports for known node builtins are only ever used in `.server.ts` files.
+
+### `use-loader-data-types`:
+
+Ensures that `useLoaderData` is given a type parameter to explicitly declare its data type.

--- a/README.md
+++ b/README.md
@@ -16,4 +16,13 @@ Ensures that all imports for known node builtins are only ever used in `.server.
 
 ### `use-loader-data-types`:
 
-Ensures that `useLoaderData` is given a type parameter to explicitly declare its data type.
+When using TypeScript, this rule ensures that `useLoaderData` is passed a generic type of the loader function to explicitly declare what it returns. It is recommended you use this with [`eslint-plugin-react-hooks`](https://www.npmjs.com/package/eslint-plugin-react-hooks).
+
+```ts
+export const loader = ...;
+
+export default function Home() {
+  // Ensures that `<typeof loader>` exists here
+  const data = useLoaderData<typeof loader>();
+}
+```

--- a/package.json
+++ b/package.json
@@ -36,8 +36,6 @@
 		"@types/estree": "^0.0.51",
 		"@types/jest": "^27.4.1",
 		"@types/node": "^17.0.21",
-		"@typescript-eslint/parser": "^5.42.0",
-		"@typescript-eslint/utils": "^5.42.0",
 		"alistair": "^1.3.1",
 		"common-tags": "^1.8.2",
 		"eslint": "^8.10.0",
@@ -48,10 +46,8 @@
 		"typescript": "^4.6.2"
 	},
 	"dependencies": {
+		"@typescript-eslint/parser": "^5.42.0",
+		"@typescript-eslint/utils": "^5.42.0",
 		"builtin-modules": "^3.2.0"
-	},
-	"peerDependencies": {
-		"@typescript-eslint/parser": "^5",
-		"@typescript-eslint/utils": "^5"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
 		"@types/estree": "^0.0.51",
 		"@types/jest": "^27.4.1",
 		"@types/node": "^17.0.21",
+		"@typescript-eslint/parser": "^5.42.0",
+		"@typescript-eslint/utils": "^5.42.0",
 		"alistair": "^1.3.1",
 		"common-tags": "^1.8.2",
 		"eslint": "^8.10.0",
@@ -47,5 +49,9 @@
 	},
 	"dependencies": {
 		"builtin-modules": "^3.2.0"
+	},
+	"peerDependencies": {
+		"@typescript-eslint/parser": "^5",
+		"@typescript-eslint/utils": "^5"
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
 import {nodeServerImports} from './rules/node-server-imports';
+import {useLoaderDataTypes} from './rules/use-loader-data-types';
 
 const config = {
 	rules: {
+		'use-loader-data-types': useLoaderDataTypes,
 		'node-server-imports': nodeServerImports,
 	},
 };

--- a/src/rules/use-loader-data-types/index.ts
+++ b/src/rules/use-loader-data-types/index.ts
@@ -1,0 +1,78 @@
+import {AST_NODE_TYPES, ESLintUtils, TSESTree} from '@typescript-eslint/utils';
+
+export const useLoaderDataTypes = ESLintUtils.RuleCreator.withoutDocs({
+	create: context => {
+		return {
+			'CallExpression[callee.name="useLoaderData"]'(
+				node: TSESTree.CallExpression,
+			) {
+				if (!node.typeParameters) {
+					context.report({
+						suggest: [
+							{
+								messageId: 'suggestMissingFix',
+								fix: fixer => [
+									fixer.insertTextAfter(node.callee, '<typeof loader>'),
+								],
+							},
+						],
+						messageId: 'missing',
+						node,
+					});
+					return;
+				}
+
+				const {typeParameters} = node;
+
+				if (
+					typeParameters.params.length !== 1 ||
+					getTypeParameterTypeQueryName(typeParameters.params[0]) !== 'loader'
+				) {
+					context.report({
+						suggest: [
+							{
+								messageId: 'suggestIncorrectFix',
+								fix: fixer => [
+									fixer.replaceTextRange(
+										typeParameters.range,
+										'<typeof loader>',
+									),
+								],
+							},
+						],
+						messageId: 'incorrect',
+						node,
+					});
+				}
+			},
+		};
+	},
+	defaultOptions: [],
+	meta: {
+		messages: {
+			incorrect:
+				'Prefer a `<typeof loader>` type parameter to safely type this call.',
+			missing:
+				'Prefer using an explicit `<typeof loader>` type parameter to safely type this call.',
+			suggestIncorrectFix:
+				'Use `<typeof loader> type parameter to safely type this call.',
+			suggestMissingFix:
+				'Add a `<typeof loader> type parameter to safely type this call.',
+		},
+		hasSuggestions: true,
+		docs: {
+			description:
+				'Ensures that useLoaderData calls have proper type information.',
+			recommended: 'warn',
+		},
+		type: 'problem',
+		schema: [],
+	},
+});
+function getTypeParameterTypeQueryName(node: TSESTree.TypeNode) {
+	return (
+		node.type === AST_NODE_TYPES.TSTypeQuery &&
+		node.exprName.type === AST_NODE_TYPES.Identifier &&
+		node.exprName.name
+	);
+}

--- a/test/use-loader-data-types.test.ts
+++ b/test/use-loader-data-types.test.ts
@@ -1,0 +1,59 @@
+import {ESLintUtils} from '@typescript-eslint/utils';
+import plugin from '../src';
+
+const ruleTester = new ESLintUtils.RuleTester({
+	parser: '@typescript-eslint/parser',
+});
+
+ruleTester.run('use-loader-data-types', plugin.rules['use-loader-data-types'], {
+	valid: [
+		'useEffect()',
+		'useState()',
+		'useOtherLoader()',
+		'userLoaderData<typeof loader>()',
+	],
+	invalid: [
+		{
+			code: 'useLoaderData()',
+			errors: [
+				{
+					messageId: 'missing',
+					suggestions: [
+						{
+							messageId: 'suggestMissingFix',
+							output: 'useLoaderData<typeof loader>()',
+						},
+					],
+				},
+			],
+		},
+		{
+			code: 'useLoaderData<other>()',
+			errors: [
+				{
+					messageId: 'incorrect',
+					suggestions: [
+						{
+							messageId: 'suggestIncorrectFix',
+							output: 'useLoaderData<typeof loader>()',
+						},
+					],
+				},
+			],
+		},
+		{
+			code: 'useLoaderData<typeof other>()',
+			errors: [
+				{
+					messageId: 'incorrect',
+					suggestions: [
+						{
+							messageId: 'suggestIncorrectFix',
+							output: 'useLoaderData<typeof loader>()',
+						},
+					],
+				},
+			],
+		},
+	],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -928,6 +928,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/json-schema@npm:^7.0.9":
+  version: 7.0.11
+  resolution: "@types/json-schema@npm:7.0.11"
+  checksum: 527bddfe62db9012fccd7627794bd4c71beb77601861055d87e3ee464f2217c85fca7a4b56ae677478367bbd248dbde13553312b7d4dbc702a2f2bbf60c4018d
+  languageName: node
+  linkType: hard
+
 "@types/node@npm:*":
   version: 17.0.18
   resolution: "@types/node@npm:17.0.18"
@@ -946,6 +953,13 @@ __metadata:
   version: 2.4.4
   resolution: "@types/prettier@npm:2.4.4"
   checksum: 2c2cc57efd49c7d8907415a72f96c84a6dd8696dd3bf8aa4ca3a667427bebf71cbfbc912673624bdfc935d272d1c008c639cf155f6449315990a4dc110f0d216
+  languageName: node
+  linkType: hard
+
+"@types/semver@npm:^7.3.12":
+  version: 7.3.13
+  resolution: "@types/semver@npm:7.3.13"
+  checksum: 00c0724d54757c2f4bc60b5032fe91cda6410e48689633d5f35ece8a0a66445e3e57fa1d6e07eb780f792e82ac542948ec4d0b76eb3484297b79bd18b8cf1cb0
   languageName: node
   linkType: hard
 
@@ -969,6 +983,86 @@ __metadata:
   dependencies:
     "@types/yargs-parser": "*"
   checksum: caa21d2c957592fe2184a8368c8cbe5a82a6c2e2f2893722e489f842dc5963293d2f3120bc06fe3933d60a3a0d1e2eb269649fd6b1947fe1820f8841ba611dd9
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/parser@npm:^5.42.0":
+  version: 5.42.0
+  resolution: "@typescript-eslint/parser@npm:5.42.0"
+  dependencies:
+    "@typescript-eslint/scope-manager": 5.42.0
+    "@typescript-eslint/types": 5.42.0
+    "@typescript-eslint/typescript-estree": 5.42.0
+    debug: ^4.3.4
+  peerDependencies:
+    eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 790d5fcc53f02a25628b1d2a06e3b7f26f4fa12e78f51a67e1db0ac6a4b643a34f247991d7b938f45c7f8395fcaf920807c8a29d768913a7a8266162d2244806
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/scope-manager@npm:5.42.0":
+  version: 5.42.0
+  resolution: "@typescript-eslint/scope-manager@npm:5.42.0"
+  dependencies:
+    "@typescript-eslint/types": 5.42.0
+    "@typescript-eslint/visitor-keys": 5.42.0
+  checksum: c7dac787c27db640ef8add18e91f84ade36871a50e84f36604fc1b823fc544ad28cea4731c4b7cadec157964f5399e6db2b3a9a115b2a2dd97fbc2bae7b1f9e0
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:5.42.0":
+  version: 5.42.0
+  resolution: "@typescript-eslint/types@npm:5.42.0"
+  checksum: 7a17ff007972129a1e2105a653d8aa637070b74d4f8b98309aeb83d06076ab40cebfa1c3e9aae3fc614118e730c4539ff13e8299d34530851cb06260483ef14c
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@npm:5.42.0":
+  version: 5.42.0
+  resolution: "@typescript-eslint/typescript-estree@npm:5.42.0"
+  dependencies:
+    "@typescript-eslint/types": 5.42.0
+    "@typescript-eslint/visitor-keys": 5.42.0
+    debug: ^4.3.4
+    globby: ^11.1.0
+    is-glob: ^4.0.3
+    semver: ^7.3.7
+    tsutils: ^3.21.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: cc8a98815daf6c8bf6f8f5e43c4a7bf7008aa850cecc669de7b8cfdddb0648fd2eae738a185165176a24aed360cb12204cc0808f251e9fcf8e436cd15fff3645
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:^5.42.0":
+  version: 5.42.0
+  resolution: "@typescript-eslint/utils@npm:5.42.0"
+  dependencies:
+    "@types/json-schema": ^7.0.9
+    "@types/semver": ^7.3.12
+    "@typescript-eslint/scope-manager": 5.42.0
+    "@typescript-eslint/types": 5.42.0
+    "@typescript-eslint/typescript-estree": 5.42.0
+    eslint-scope: ^5.1.1
+    eslint-utils: ^3.0.0
+    semver: ^7.3.7
+  peerDependencies:
+    eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+  checksum: cc57ba8bdf1cf18de5c6c264b71be80dc8c4a7630c0d6a34f73ed991cd3684c97a06605f414a8fd439ce2201f7724249b2fc29eac1e54a770ee4e8303cabef52
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:5.42.0":
+  version: 5.42.0
+  resolution: "@typescript-eslint/visitor-keys@npm:5.42.0"
+  dependencies:
+    "@typescript-eslint/types": 5.42.0
+    eslint-visitor-keys: ^3.3.0
+  checksum: d198e51ea968555dd44b3ff14587dd82ce43c30ae43d4021d4eacb468e4476102a5b715e15240adcdeec4b4b5280d819087a9c4090360f1e4dcb05829ea8f2dc
   languageName: node
   linkType: hard
 
@@ -1680,6 +1774,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:^4.3.4":
+  version: 4.3.4
+  resolution: "debug@npm:4.3.4"
+  dependencies:
+    ms: 2.1.2
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 3dbad3f94ea64f34431a9cbf0bafb61853eda57bff2880036153438f50fb5a84f27683ba0d8e5426bf41a8c6ff03879488120cf5b3a761e77953169c0600a708
+  languageName: node
+  linkType: hard
+
 "decimal.js@npm:^10.2.1":
   version: 10.3.1
   resolution: "decimal.js@npm:10.3.1"
@@ -2088,6 +2194,8 @@ __metadata:
     "@types/estree": ^0.0.51
     "@types/jest": ^27.4.1
     "@types/node": ^17.0.21
+    "@typescript-eslint/parser": ^5.42.0
+    "@typescript-eslint/utils": ^5.42.0
     alistair: ^1.3.1
     builtin-modules: ^3.2.0
     common-tags: ^1.8.2
@@ -2097,8 +2205,21 @@ __metadata:
     ts-node: ^10.7.0
     tsup: ^5.12.0
     typescript: ^4.6.2
+  peerDependencies:
+    "@typescript-eslint/parser": ^5
+    "@typescript-eslint/utils": ^5
   languageName: unknown
   linkType: soft
+
+"eslint-scope@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "eslint-scope@npm:5.1.1"
+  dependencies:
+    esrecurse: ^4.3.0
+    estraverse: ^4.1.1
+  checksum: 47e4b6a3f0cc29c7feedee6c67b225a2da7e155802c6ea13bbef4ac6b9e10c66cd2dcb987867ef176292bf4e64eccc680a49e35e9e9c669f4a02bac17e86abdb
+  languageName: node
+  linkType: hard
 
 "eslint-scope@npm:^7.1.1":
   version: 7.1.1
@@ -2216,6 +2337,13 @@ __metadata:
   dependencies:
     estraverse: ^5.2.0
   checksum: ebc17b1a33c51cef46fdc28b958994b1dc43cd2e86237515cbc3b4e5d2be6a811b2315d0a1a4d9d340b6d2308b15322f5c8291059521cc5f4802f65e7ec32837
+  languageName: node
+  linkType: hard
+
+"estraverse@npm:^4.1.1":
+  version: 4.3.0
+  resolution: "estraverse@npm:4.3.0"
+  checksum: a6299491f9940bb246124a8d44b7b7a413a8336f5436f9837aaa9330209bd9ee8af7e91a654a3545aee9c54b3308e78ee360cef1d777d37cfef77d2fa33b5827
   languageName: node
   linkType: hard
 
@@ -2533,7 +2661,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^11.0.3":
+"globby@npm:^11.0.3, globby@npm:^11.1.0":
   version: 11.1.0
   resolution: "globby@npm:11.1.0"
   dependencies:
@@ -4368,6 +4496,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.3.7":
+  version: 7.3.8
+  resolution: "semver@npm:7.3.8"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: ba9c7cbbf2b7884696523450a61fee1a09930d888b7a8d7579025ad93d459b2d1949ee5bbfeb188b2be5f4ac163544c5e98491ad6152df34154feebc2cc337c1
+  languageName: node
+  linkType: hard
+
 "set-blocking@npm:^2.0.0":
   version: 2.0.0
   resolution: "set-blocking@npm:2.0.0"
@@ -4788,6 +4927,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:^1.8.1":
+  version: 1.14.1
+  resolution: "tslib@npm:1.14.1"
+  checksum: dbe628ef87f66691d5d2959b3e41b9ca0045c3ee3c7c7b906cc1e328b39f199bb1ad9e671c39025bd56122ac57dfbf7385a94843b1cc07c60a4db74795829acd
+  languageName: node
+  linkType: hard
+
 "tsup@npm:^5.12.0":
   version: 5.12.0
   resolution: "tsup@npm:5.12.0"
@@ -4815,6 +4961,17 @@ __metadata:
     tsup: dist/cli-default.js
     tsup-node: dist/cli-node.js
   checksum: 43a741fbc4ec44681747d610a10d0a5b0939c489609c2ac46063e3cbc53eb4afa9ce2de8697267a3f39b21fccd7b1ae09af98904c1bdf44363472636869fcc1c
+  languageName: node
+  linkType: hard
+
+"tsutils@npm:^3.21.0":
+  version: 3.21.0
+  resolution: "tsutils@npm:3.21.0"
+  dependencies:
+    tslib: ^1.8.1
+  peerDependencies:
+    typescript: ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+  checksum: 1843f4c1b2e0f975e08c4c21caa4af4f7f65a12ac1b81b3b8489366826259323feb3fc7a243123453d2d1a02314205a7634e048d4a8009921da19f99755cdc48
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2205,9 +2205,6 @@ __metadata:
     ts-node: ^10.7.0
     tsup: ^5.12.0
     typescript: ^4.6.2
-  peerDependencies:
-    "@typescript-eslint/parser": ^5
-    "@typescript-eslint/utils": ^5
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Sending as a draft for reference - hi @alii, nice to meet you! 😄 

This PR is in response to https://twitter.com/TkDodo/status/1586450960385294337 - a few folks on Twitter talking about how it'd be nice to have a lint rule to enforce that `useLoaderData` is called like `useLoaderData<typeof loader>()`, for maximum type safety.

I added a dependency on `@typescript-eslint/parser` and `@typescript-eslint/utils` for type safety, to get `TSESTree.CallExpression`. Again, just throwing this up as a reference - @alii I'm happy to close if you think this doesn't belong here, or change as you'd like!

Note that this version of a `use-loader-data-types` rule is very straightforward and not particularly smart. For example, it doesn't use `@typescript-eslint/scope-analysis` to check whether a `loader` even exists in the file.